### PR TITLE
Fixed error on Android when API level <23

### DIFF
--- a/FilePicker/FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
+++ b/FilePicker/FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
@@ -25,22 +25,33 @@ namespace Plugin.FilePicker
         {
             base.OnCreate(savedInstanceState);
             Bundle b = (savedInstanceState ?? Intent.Extras);
-            if (CheckSelfPermission(Manifest.Permission.ReadExternalStorage) == (int)Permission.Granted)
-            {
-                launchPicker();
+
+            if (Build.VERSION.SDK_INT >= 23) 
+            { 
+                if (CheckSelfPermission(Manifest.Permission.ReadExternalStorage) == (int)Permission.Granted)
+                {
+                    launchPicker();
+                }
+                else
+                {
+                    RequestPermissions(new String[] { Manifest.Permission.ReadExternalStorage }, REQUEST_STORAGE);
+                }
             }
             else
             {
-                RequestPermissions(new String[] { Manifest.Permission.ReadExternalStorage }, REQUEST_STORAGE);
+                launchPicker();
             }
         }
 
         public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
         {
-            if(requestCode == REQUEST_STORAGE) {
-                if(grantResults[0] == Permission.Granted) {
+            if(requestCode == REQUEST_STORAGE) 
+            {
+                if(grantResults[0] == Permission.Granted) 
+                {
                     launchPicker();
-                } else
+                } 
+                else
                 {
                     Toast.MakeText(this, "File Permission Denied.", ToastLength.Long).Show();
                     OnFilePickCancelled();


### PR DESCRIPTION
Given that CheckSelfPermission was introduced in API level 23 the plugin currently throws an error when used under API level 23. I added check that CheckSelfPermission gets only used when the API level is >= 23.

Additionlly, I reformated the code, so that the bracket where an open bracket begins on the next line is consistent with the old code.